### PR TITLE
[fix] Case Sensitive namespace fix for Composer's autoloader

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -68,7 +68,7 @@ $app->configureMode('production', function () use ($app) {
 /******************************************** THE MODEL ********************************************************/
 
 // Initialize the model, pass the database configs. $model can now perform all methods from Mini\model\model.php
-$model = new \Mini\Model\Model($app->config('database'));
+$model = new \Mini\model\model($app->config('database'));
 
 /************************************ THE ROUTES / CONTROLLERS *************************************************/
 


### PR DESCRIPTION
On local both variants works. But on some hosting environments not.
[composer#2767](https://github.com/composer/composer/issues/2767)
